### PR TITLE
Opt out of num default features: don't need rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ doctest = true
 doc = true
 
 [dependencies]
-num = "0.1"
+num = { version = "0.1", default-features = false }


### PR DESCRIPTION
`num` has the optional dependency `rand`, mainly for randomized testing. `rand`, in turn, pulls in a lot of extra dependencies, none of which this crate needs. The result is an overly long build time. This fixes it.
