### PR TITLE
Use the smaller num-traits dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ doctest = true
 doc = true
 
 [dependencies]
-num = { version = "0.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@
 //! }
 //! ```
 
-extern crate num;
-use num::{Zero, NumCast};
+extern crate num_traits;
+use num_traits::{Zero, NumCast};
 
 use std::mem;
 use std::cmp::{Ordering,PartialOrd};


### PR DESCRIPTION
There's no reason to pull in the larger `num` meta-crate, when only a
couple traits are needed.  On its own, `num-traits` now even supports
`#![no_std]` builds when the default `std` feature isn't enabled.

Note, this is not a breaking change, even though the traits are in the
public API of `float-cmp`, because they are the exact same that `num`
just re-exports.