### PR TITLE
add support for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ doctest = true
 doc = true
 
 [features]
-default = [ "num-traits" ]
+default = [ "num-traits", "std" ]
+std = []
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false, optional = true }

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -1,7 +1,10 @@
 // Copyright 2014-2018 Optimal Computing (NZ) Ltd.
 // Licensed under the MIT license.  See LICENSE for details.
 
-use std::{f32,f64};
+use core::{f32, f64};
+#[cfg(feature = "num-traits")]
+#[allow(unused_imports)]
+use num_traits::float::FloatCore;
 use super::Ulps;
 
 /// A trait for approximate equality comparisons.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,12 +170,15 @@
 //!
 //! [https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/](https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/)
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(feature="num-traits")]
 extern crate num_traits;
 
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "std")]
 pub fn trials() {
     println!("are they approximately equal?: {:?}",
              approx_eq!(f32, 1.0, 1.0000001));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,7 +26,7 @@ macro_rules! saturating_abs_i32 {
         if $val.is_negative() {
             match $val.checked_neg() {
                 Some(v) => v,
-                None => std::i32::MAX
+                None => core::i32::MAX
             }
         } else {
             $val
@@ -38,7 +38,7 @@ macro_rules! saturating_abs_i64 {
         if $val.is_negative() {
             match $val.checked_neg() {
                 Some(v) => v,
-                None => std::i64::MAX
+                None => core::i64::MAX
             }
         } else {
             $val

--- a/src/ratio.rs
+++ b/src/ratio.rs
@@ -1,8 +1,8 @@
 // Copyright 2014-2018 Optimal Computing (NZ) Ltd.
 // Licensed under the MIT license.  See LICENSE for details.
 
-use std::cmp::PartialOrd;
-use std::ops::{Sub,Div,Neg};
+use core::cmp::PartialOrd;
+use core::ops::{Sub, Div, Neg};
 use num_traits::Zero;
 
 /// ApproxEqRatio is a trait for approximate equality comparisons bounding the ratio


### PR DESCRIPTION
To enable support for no_std, the new std feature simply needs to be disabled.