### PR TITLE
enable no_std unconditionally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Floating point approximate comparison traits"
 repository = "https://github.com/mikedilger/float-cmp"
 documentation = "https://docs.rs/float-cmp"
 readme = "README.md"
-keywords = [ "float", "comparison", "fuzzy", "approximate" ]
+keywords = [ "float", "comparison", "fuzzy", "approximate", "no_std" ]
 license = "MIT"
 edition = "2018"
 
@@ -18,8 +18,7 @@ doctest = true
 doc = true
 
 [features]
-default = [ "num-traits", "std" ]
-std = []
+default = [ "num-traits" ]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false, optional = true }

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -139,7 +139,6 @@ fn f32_approx_eq_test5() {
     for _ in 0_isize..10_isize { sum += f; }
     let product: f32 = f * 10.0_f32;
     assert!(sum != product); // Should not be directly equal:
-    println!("Ulps Difference: {}",sum.ulps(&product));
     assert!(sum.approx_eq(product, (f32::EPSILON, 1)) == true);
     assert!(sum.approx_eq(product, F32Margin::zero()) == false);
 }
@@ -267,7 +266,6 @@ fn f64_approx_eq_test5() {
     for _ in 0_isize..10_isize { sum += f; }
     let product: f64 = f * 10.0_f64;
     assert!(sum != product); // Should not be precisely equaly.
-    println!("Ulps Difference: {}",sum.ulps(&product));
     assert!(sum.approx_eq(product, (f64::EPSILON, 0)) == true);
     assert!(sum.approx_eq(product, (0.0, 1)) == true);
 }
@@ -276,7 +274,6 @@ fn f64_approx_eq_test6() {
     let x: f64 = 1000000_f64;
     let y: f64 = 1000000.0000000003_f64;
     assert!(x != y); // Should not be precisely equal.
-    println!("Ulps Difference: {}",x.ulps(&y));
     assert!(x.approx_eq(y, (0.0, 3)) == true);
 }
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@
 //!
 //! [https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/](https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/)
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 #[cfg(feature="num-traits")]
 extern crate num_traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,12 +178,6 @@ extern crate num_traits;
 #[macro_use]
 mod macros;
 
-#[cfg(feature = "std")]
-pub fn trials() {
-    println!("are they approximately equal?: {:?}",
-             approx_eq!(f32, 1.0, 1.0000001));
-}
-
 mod ulps;
 pub use self::ulps::Ulps;
 

--- a/src/ulps.rs
+++ b/src/ulps.rs
@@ -93,7 +93,6 @@ impl Ulps for f32 {
 fn f32_ulps_test1() {
     let x: f32 = 1000000_f32;
     let y: f32 = 1000000.1_f32;
-    println!("DIST IS {}",x.ulps(&y));
     assert!(x.ulps(&y) == -2);
 }
 
@@ -101,14 +100,12 @@ fn f32_ulps_test1() {
 fn f32_ulps_test2() {
     let pzero: f32 = f32::from_bits(0x00000000_u32);
     let nzero: f32 = f32::from_bits(0x80000000_u32);
-    println!("DIST IS {}",pzero.ulps(&nzero));
     assert!(pzero.ulps(&nzero) == -2147483648);
 }
 #[test]
 fn f32_ulps_test3() {
     let pinf: f32 = f32::from_bits(0x7f800000_u32);
     let ninf: f32 = f32::from_bits(0xff800000_u32);
-    println!("DIST IS {}",pinf.ulps(&ninf));
     assert!(pinf.ulps(&ninf) == -2147483648);
 }
 
@@ -116,7 +113,6 @@ fn f32_ulps_test3() {
 fn f32_ulps_test4() {
     let x: f32 = f32::from_bits(0x63a7f026_u32);
     let y: f32 = f32::from_bits(0x63a7f023_u32);
-    println!("DIST IS {}",x.ulps(&y));
     assert!(x.ulps(&y) == 3);
 }
 
@@ -193,7 +189,6 @@ impl Ulps for f64 {
 fn f64_ulps_test1() {
     let x: f64 = 1000000_f64;
     let y: f64 = 1000000.00000001_f64;
-    println!("DIST IS {}",x.ulps(&y));
     assert!(x.ulps(&y) == -86);
 }
 
@@ -201,14 +196,12 @@ fn f64_ulps_test1() {
 fn f64_ulps_test2() {
     let pzero: f64 = f64::from_bits(0x0000000000000000_u64);
     let nzero: f64 = f64::from_bits(0x8000000000000000_u64);
-    println!("DIST IS {}",pzero.ulps(&nzero));
     assert!(pzero.ulps(&nzero) == -9223372036854775808i64);
 }
 #[test]
 fn f64_ulps_test3() {
     let pinf: f64 = f64::from_bits(0x7f80000000000000_u64);
     let ninf: f64 = f64::from_bits(0xff80000000000000_u64);
-    println!("DIST IS {}",pinf.ulps(&ninf));
     assert!(pinf.ulps(&ninf) == -9223372036854775808i64);
 }
 
@@ -216,7 +209,6 @@ fn f64_ulps_test3() {
 fn f64_ulps_test4() {
     let x: f64 = f64::from_bits(0xd017f6cc63a7f026_u64);
     let y: f64 = f64::from_bits(0xd017f6cc63a7f023_u64);
-    println!("DIST IS {}",x.ulps(&y));
     assert!(x.ulps(&y) == 3);
 }
 

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -53,7 +53,6 @@ fn f32_approx_eq_ulps_test1() {
     for _ in 0_isize..10_isize { sum += f; }
     let product: f32 = f * 10.0_f32;
     assert!(sum != product); // Should not be directly equal:
-    println!("Ulps Difference: {}",sum.ulps(&product));
     assert!(sum.approx_eq_ulps(&product,1) == true); // But should be close
     assert!(sum.approx_eq_ulps(&product,0) == false);
 }
@@ -62,7 +61,6 @@ fn f32_approx_eq_ulps_test2() {
     let x: f32 = 1000000_f32;
     let y: f32 = 1000000.1_f32;
     assert!(x != y); // Should not be directly equal
-    println!("Ulps Difference: {}",x.ulps(&y));
     assert!(x.approx_eq_ulps(&y,2) == true);
     assert!(x.approx_eq_ulps(&y,1) == false);
 }
@@ -98,7 +96,6 @@ fn f64_approx_eq_ulps_test1() {
     for _ in 0_isize..10_isize { sum += f; }
     let product: f64 = f * 10.0_f64;
     assert!(sum != product); // Should not be directly equal:
-    println!("Ulps Difference: {}",sum.ulps(&product));
     assert!(sum.approx_eq_ulps(&product,1) == true); // But should be close
     assert!(sum.approx_eq_ulps(&product,0) == false);
 }
@@ -107,7 +104,6 @@ fn f64_approx_eq_ulps_test2() {
     let x: f64 = 1000000_f64;
     let y: f64 = 1000000.0000000003_f64;
     assert!(x != y); // Should not be directly equal
-    println!("Ulps Difference: {}",x.ulps(&y));
     assert!(x.approx_eq_ulps(&y,3) == true);
     assert!(x.approx_eq_ulps(&y,2) == false);
 }


### PR DESCRIPTION
This includes removing all `println!()` in `#[test]` and removing the `trials()` function.