### PR TITLE
Avoid literal use of Default::default

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,7 @@
 macro_rules! approx_eq {
     ($typ:ty, $lhs:expr, $rhs:expr) => {
         {
-            let m: <$typ as $crate::ApproxEq>::Margin = Default::default();
+            let m = <$typ as $crate::ApproxEq>::Margin::default();
             <$typ as $crate::ApproxEq>::approx_eq($lhs, $rhs, m)
         }
     };


### PR DESCRIPTION
Using the `approx_eq` macro with the [default_trait_access][1] **clippy** rule:

```rust
#![warn(clippy::default_trait_access)]

use float_cmp::approx_eq;

fn main() {
    assert!(approx_eq!(f64, 2.0, 1.0 + 1.0));
}
```

... causes **clippy** to show this message:

```console
$ cargo clippy
warning: calling `float_cmp::F64Margin::default()` is more clear than this expression
 --> src/main.rs:6:13
  |
6 |     assert!(approx_eq!(f64, 2.0, 1.0 + 1.0));
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
note: the lint level is defined here
 --> src/main.rs:1:9
  |
1 | #![warn(clippy::default_trait_access)]
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is due to the literal use of `Default::default` in the `approx_eq` macro. The macro gets expanded into the code of others. Everyone with that **clippy** rule enabled will see the message as warning, or error, depending on their configuration, which can be annoying.

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access